### PR TITLE
_config.yml: typo in the description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@
 title: OpenPMIx
 #email: pmix@example.com
 description: >- # this means to ignore newlines until "baseurl:"
-  Reference Implmentation of the
+  Reference Implementation of the
   Process Management Interface Exascale (PMIx) standard
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com


### PR DESCRIPTION
I see "Implmentation" instead of "Implementation" in several places in the website and this yml description is the only matching typo in the repo, let's hope that's enough.